### PR TITLE
Implement signout functionality in navbar

### DIFF
--- a/src/app/layout/navbar/navbar.spec.ts
+++ b/src/app/layout/navbar/navbar.spec.ts
@@ -6,11 +6,13 @@ import { vi } from 'vitest';
 import { NavbarComponent as Navbar } from './navbar';
 import { UserApiService } from '../../core/openapi/api/user.service';
 import { UserDto } from '../../core/openapi/model/userDto';
+import { AuthService } from '../../services/auth.service';
 
 describe('Navbar', () => {
   let component: Navbar;
   let fixture: ComponentFixture<Navbar>;
   let mockUserApiService: { getCurrentUser: ReturnType<typeof vi.fn> };
+  let mockAuthService: { logout: ReturnType<typeof vi.fn> };
 
   const mockUser: UserDto = {
     id: '123',
@@ -36,11 +38,16 @@ describe('Navbar', () => {
       getCurrentUser: vi.fn().mockReturnValue(of(mockUser)),
     };
 
+    mockAuthService = {
+      logout: vi.fn().mockReturnValue(of(undefined)),
+    };
+
     await TestBed.configureTestingModule({
       imports: [Navbar],
       providers: [
         provideZonelessChangeDetection(),
         { provide: UserApiService, useValue: mockUserApiService },
+        { provide: AuthService, useValue: mockAuthService },
       ],
     }).compileComponents();
 
@@ -148,5 +155,31 @@ describe('Navbar', () => {
     const menuItem = { id: '1', label: 'Profile', icon: 'user', action: 'profile' };
     component.onUserMenuClick(menuItem);
     expect(component.userMenuClick.emit).toHaveBeenCalledWith(menuItem);
+  });
+
+  it('should call authService.logout when user clicks logout menu item', () => {
+    const logoutMenuItem = { id: 'logout', label: 'Logout', icon: 'logout', action: 'logout' };
+    component.onUserMenuClick(logoutMenuItem);
+    expect(mockAuthService.logout).toHaveBeenCalled();
+  });
+
+  it('should not emit userMenuClick event when logout action is triggered', () => {
+    vi.spyOn(component.userMenuClick, 'emit');
+    const logoutMenuItem = { id: 'logout', label: 'Logout', icon: 'logout', action: 'logout' };
+    component.onUserMenuClick(logoutMenuItem);
+    expect(component.userMenuClick.emit).not.toHaveBeenCalled();
+  });
+
+  it('should emit userMenuClick event for non-logout actions', () => {
+    vi.spyOn(component.userMenuClick, 'emit');
+    const settingsMenuItem = {
+      id: 'settings',
+      label: 'Settings',
+      icon: 'settings',
+      action: 'settings',
+    };
+    component.onUserMenuClick(settingsMenuItem);
+    expect(component.userMenuClick.emit).toHaveBeenCalledWith(settingsMenuItem);
+    expect(mockAuthService.logout).not.toHaveBeenCalled();
   });
 });

--- a/src/app/layout/navbar/navbar.ts
+++ b/src/app/layout/navbar/navbar.ts
@@ -8,6 +8,7 @@ import { AppsMenu, AppMenuItem } from '../../components/ui/apps-menu/apps-menu';
 import { UserMenu, UserMenuItem } from '../../components/ui/user-menu/user-menu';
 import { UserApiService } from '../../core/openapi/api/user.service';
 import { UserDto } from '../../core/openapi/model/userDto';
+import { AuthService } from '../../services/auth.service';
 import { catchError, tap } from 'rxjs/operators';
 import { of } from 'rxjs';
 
@@ -20,6 +21,7 @@ import { of } from 'rxjs';
 export class NavbarComponent implements OnInit {
   // Services
   private userApiService = inject(UserApiService);
+  private authService = inject(AuthService);
 
   // Signals
   currentUser = signal<UserDto | null>(null);
@@ -117,6 +119,16 @@ export class NavbarComponent implements OnInit {
   }
 
   onUserMenuClick(item: UserMenuItem): void {
+    // Handle logout action
+    if (item.action === 'logout') {
+      this.handleLogout();
+      return;
+    }
+
     this.userMenuClick.emit(item);
+  }
+
+  private handleLogout(): void {
+    this.authService.logout().subscribe();
   }
 }


### PR DESCRIPTION
## Resumen

Implementa la funcionalidad de cierre de sesión (signout/logout) en el navbar, permitiendo al usuario cerrar sesión desde el menú de usuario.

## Cambios Realizados

- ✅ Inyectado `AuthService` en el componente `NavbarComponent`
- ✅ Implementado manejo del evento de logout en `onUserMenuClick`
- ✅ Llamada al método `logout()` del `AuthService` cuando el usuario hace clic en logout
- ✅ Agregados 3 tests unitarios para cubrir la funcionalidad de logout:
  - Test para verificar que se llama `authService.logout()`
  - Test para verificar que NO se emite evento `userMenuClick` en logout
  - Test para verificar que SÍ se emite evento para acciones no-logout
- ✅ Ejecutado lint y prettier sin errores

## Checklist de Tests

- [x] Tests unitarios pasan (530 tests passing)
- [x] Lint ejecutado sin errores
- [x] Prettier ejecutado y formateado aplicado
- [x] No se modificó código generado en `src/app/core/openapi/**`

## Archivos Modificados

- `src/app/layout/navbar/navbar.ts` (+12 líneas)
- `src/app/layout/navbar/navbar.spec.ts` (+33 líneas)

## Notas Técnicas

- El `AuthService` ya tenía implementado el método `logout()` que:
  - Llama al endpoint de logout del API
  - Limpia el token local
  - Redirige al usuario a la página de login
- La implementación verifica si `item.action === 'logout'` para manejar la acción
- Se previene la emisión del evento `userMenuClick` para acciones de logout

## Screenshots/Resultados

```bash
✓ All tests passed (530 tests)
✓ Lint: All files pass linting
✓ Prettier: All files formatted correctly
```

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)