### PR TITLE
feat(icon): add standalone icon component

### DIFF
--- a/public/assets/icons/check.svg
+++ b/public/assets/icons/check.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path
+    d="M5 12.5L9.5 17 19 7.5"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>
+

--- a/public/assets/icons/logo.svg
+++ b/public/assets/icons/logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <circle cx="32" cy="32" r="30" stroke="currentColor" stroke-width="4" />
+  <path
+    d="M20 36c3.5-6 9-10 12-12 3 2 8.5 6 12 12"
+    stroke="currentColor"
+    stroke-width="4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M24 44c2.5 2 5.5 3 8 3s5.5-1 8-3"
+    fill="currentColor"
+    opacity="0.2"
+  />
+</svg>
+

--- a/src/app/components/ui/README.md
+++ b/src/app/components/ui/README.md
@@ -10,11 +10,12 @@ Componentes UI reutilizables y completamente funcionales construidos con Angular
 2. **MultiSelect** - Selector múltiple con checkboxes
 3. **Modal** - Diálogo modal con backdrop
 4. **Accordion** - Acordeón expandible/colapsable
+5. **Icon** - Carga y cacheo de SVGs inline desde assets
 
 ### 🚧 Componentes Pendientes
 
-5. **Tooltip** - Tooltip al hover
-6. **DatePicker** - Selector de fecha
+1. **Tooltip** - Tooltip al hover
+2. **DatePicker** - Selector de fecha
 
 ---
 
@@ -89,6 +90,43 @@ interface DropdownItem {
   divider?: boolean;
 }
 ```
+
+---
+
+## 🎯 Icon Component
+
+Servicio y componente para incrustar SVGs inline con soporte para temas y accesibilidad.
+
+### Características
+
+- ✅ Carga SVGs desde `public/assets/icons`
+- ✅ Cachea las peticiones para evitar múltiples requests
+- ✅ Soporta tamaños predefinidos (`sm`, `md`, `lg`) o valores numéricos en píxeles
+- ✅ Accesible mediante `aria-label` y `role="img"`
+- ✅ Hereda el color mediante `currentColor`
+
+### Uso Básico
+
+```typescript
+import { IconComponent } from '@app/components/ui/icon/icon';
+
+@Component({
+  selector: 'app-dashboard',
+  standalone: true,
+  imports: [IconComponent],
+  template: ` <app-icon name="check" ariaLabel="Estado OK" class="text-emerald-500" /> `,
+})
+export class DashboardComponent {}
+```
+
+### API
+
+**Inputs:**
+
+- `name: string` - (Requerido) Nombre del SVG a cargar (sin extensión)
+- `size: 'sm' | 'md' | 'lg' | number` - Tamaño del icono (default: `md`)
+- `ariaLabel?: string` - Etiqueta accesible (define `role="img"` automáticamente)
+- `class?: string` - Clases adicionales aplicadas al host
 
 ---
 

--- a/src/app/components/ui/icon/icon.css
+++ b/src/app/components/ui/icon/icon.css
@@ -1,0 +1,32 @@
+:host {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+  color: currentColor;
+}
+
+:host(.app-icon) {
+  flex-shrink: 0;
+}
+
+:host(.app-icon--sm) {
+  width: 1rem;
+  height: 1rem;
+}
+
+:host(.app-icon--md) {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+:host(.app-icon--lg) {
+  width: 2rem;
+  height: 2rem;
+}
+
+:host svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}

--- a/src/app/components/ui/icon/icon.html
+++ b/src/app/components/ui/icon/icon.html
@@ -1,0 +1,1 @@
+<!-- SVG content is injected via host bindings -->

--- a/src/app/components/ui/icon/icon.service.ts
+++ b/src/app/components/ui/icon/icon.service.ts
@@ -1,0 +1,47 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { Observable, of, shareReplay, map, tap } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class IconService {
+  private readonly http = inject(HttpClient);
+  private readonly sanitizer = inject(DomSanitizer);
+  private readonly cache = new Map<string, Observable<SafeHtml>>();
+  private readonly emptyIcon = this.sanitizer.bypassSecurityTrustHtml('');
+
+  getSvg(name: string): Observable<SafeHtml> {
+    const normalizedName = this.normalizeName(name);
+
+    if (!normalizedName) {
+      return of(this.emptyIcon);
+    }
+
+    const cached = this.cache.get(normalizedName);
+    if (cached) {
+      return cached;
+    }
+
+    const fetch$ = this.http
+      .get(`assets/icons/${normalizedName}.svg`, {
+        responseType: 'text',
+      })
+      .pipe(
+        map((svg) => this.sanitizer.bypassSecurityTrustHtml(svg)),
+        tap({
+          error: () => this.cache.delete(normalizedName),
+        }),
+        shareReplay({ bufferSize: 1, refCount: false }),
+      );
+
+    this.cache.set(normalizedName, fetch$);
+
+    return fetch$;
+  }
+
+  private normalizeName(name: string): string {
+    return name.trim().replace(/\.svg$/i, '');
+  }
+}

--- a/src/app/components/ui/icon/icon.spec.ts
+++ b/src/app/components/ui/icon/icon.spec.ts
@@ -1,0 +1,169 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClient, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideZonelessChangeDetection, SecurityContext } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { of } from 'rxjs';
+import { IconService } from './icon.service';
+import { IconComponent } from './icon';
+
+describe('IconService', () => {
+  let service: IconService;
+  let httpMock: HttpTestingController;
+  let sanitizer: DomSanitizer;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    service = TestBed.inject(IconService);
+    httpMock = TestBed.inject(HttpTestingController);
+    sanitizer = TestBed.inject(DomSanitizer);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should load and sanitize SVG content once and cache subsequent calls', () => {
+    const svgContent = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0" /></svg>';
+    const results: SafeHtml[] = [];
+
+    service.getSvg('check').subscribe((value) => results.push(value));
+
+    const request = httpMock.expectOne('assets/icons/check.svg');
+    expect(request.request.method).toBe('GET');
+    request.flush(svgContent);
+
+    const first = sanitizer.sanitize(SecurityContext.HTML, results[0]);
+    expect(first).toContain('<svg');
+
+    service.getSvg('check').subscribe((value) => results.push(value));
+    httpMock.expectNone('assets/icons/check.svg');
+
+    const second = sanitizer.sanitize(SecurityContext.HTML, results[1]);
+    expect(second).toBe(first);
+  });
+
+  it('should normalize names with extension before fetching', () => {
+    let received: string | null = null;
+
+    service.getSvg('logo.svg').subscribe((value) => {
+      received = sanitizer.sanitize(SecurityContext.HTML, value);
+    });
+
+    const request = httpMock.expectOne('assets/icons/logo.svg');
+    request.flush('<svg />');
+
+    expect(received).not.toBeNull();
+    expect(received).toContain('<svg');
+  });
+
+  it('should allow retrying after a failed request', () => {
+    const errorResponse = { status: 404, statusText: 'Not Found' };
+    const svgContent = '<svg><rect width="10" height="10" /></svg>';
+    const successSpy = vi.fn();
+
+    service.getSvg('missing').subscribe({
+      next: successSpy,
+      error: (error) => {
+        expect(error).toBeTruthy();
+      },
+    });
+
+    const firstRequest = httpMock.expectOne('assets/icons/missing.svg');
+    firstRequest.flush('not found', errorResponse);
+
+    service.getSvg('missing').subscribe((value) => {
+      const sanitized = sanitizer.sanitize(SecurityContext.HTML, value);
+      expect(sanitized).toContain('<svg');
+    });
+
+    const secondRequest = httpMock.expectOne('assets/icons/missing.svg');
+    secondRequest.flush(svgContent);
+
+    expect(successSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('IconComponent', () => {
+  let fixture: ComponentFixture<IconComponent>;
+  let element: HTMLElement;
+  let httpClient: {
+    get: Mock;
+  };
+  let iconService: IconService;
+
+  beforeEach(async () => {
+    httpClient = {
+      get: vi.fn(() => of('<svg data-test="icon"></svg>')) as Mock,
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [IconComponent],
+      providers: [provideZonelessChangeDetection(), { provide: HttpClient, useValue: httpClient }],
+    }).compileComponents();
+
+    iconService = TestBed.inject(IconService);
+    fixture = TestBed.createComponent(IconComponent);
+    element = fixture.nativeElement;
+  });
+
+  it('should render SVG content for provided icon name', () => {
+    const serviceSpy = vi.spyOn(iconService, 'getSvg');
+    fixture.componentRef.setInput('name', 'check');
+
+    fixture.detectChanges();
+
+    expect(serviceSpy).toHaveBeenCalledWith('check');
+    expect(httpClient.get).toHaveBeenCalledWith('assets/icons/check.svg', { responseType: 'text' });
+    expect(element.innerHTML).toContain('data-test="icon"');
+  });
+
+  it('should apply aria-hidden when no ariaLabel is provided', () => {
+    fixture.componentRef.setInput('name', 'check');
+
+    fixture.detectChanges();
+
+    expect(element.getAttribute('aria-hidden')).toBe('true');
+    expect(element.getAttribute('role')).toBeNull();
+  });
+
+  it('should expose aria-label and role img when provided', () => {
+    fixture.componentRef.setInput('name', 'check');
+    fixture.componentRef.setInput('ariaLabel', 'Check icon');
+
+    fixture.detectChanges();
+
+    expect(element.getAttribute('aria-label')).toBe('Check icon');
+    expect(element.getAttribute('role')).toBe('img');
+    expect(element.getAttribute('aria-hidden')).toBeNull();
+  });
+
+  it('should reflect size variants with classes', () => {
+    fixture.componentRef.setInput('name', 'check');
+    fixture.componentRef.setInput('size', 'lg');
+
+    fixture.detectChanges();
+
+    expect(element.classList.contains('app-icon')).toBe(true);
+    expect(element.classList.contains('app-icon--lg')).toBe(true);
+  });
+
+  it('should support numeric sizes via inline styles', () => {
+    fixture.componentRef.setInput('name', 'check');
+    fixture.componentRef.setInput('size', 32);
+
+    fixture.detectChanges();
+
+    expect(element.style.width).toBe('32px');
+    expect(element.style.height).toBe('32px');
+  });
+});

--- a/src/app/components/ui/icon/icon.ts
+++ b/src/app/components/ui/icon/icon.ts
@@ -1,0 +1,88 @@
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { catchError, distinctUntilChanged, switchMap } from 'rxjs';
+import { of } from 'rxjs';
+import { IconService } from './icon.service';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+const SIZE_VARIANTS = new Set(['sm', 'md', 'lg'] as const);
+
+@Component({
+  selector: 'app-icon',
+  standalone: true,
+  templateUrl: './icon.html',
+  styleUrl: './icon.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[class.app-icon]': 'true',
+    '[class.app-icon--sm]': 'sizeClass() === "sm"',
+    '[class.app-icon--md]': 'sizeClass() === "md"',
+    '[class.app-icon--lg]': 'sizeClass() === "lg"',
+    '[innerHTML]': 'svgContent()',
+    '[attr.role]': 'roleAttr()',
+    '[attr.aria-label]': 'ariaLabelAttr()',
+    '[attr.aria-hidden]': 'ariaHiddenAttr()',
+    '[style.width.px]': 'numericSize()',
+    '[style.height.px]': 'numericSize()',
+  },
+})
+export class IconComponent {
+  private readonly iconService = inject(IconService);
+  private readonly sanitizer = inject(DomSanitizer);
+  private readonly emptyIcon = this.sanitizer.bypassSecurityTrustHtml('');
+
+  name = input.required<string>();
+  size = input<'sm' | 'md' | 'lg' | number>('md');
+  ariaLabel = input<string | null>(null);
+
+  protected readonly normalizedName = computed(() => this.normalizeName(this.name()));
+
+  private readonly iconContent = toSignal<SafeHtml | null>(
+    toObservable(this.normalizedName).pipe(
+      distinctUntilChanged(),
+      switchMap((name) => {
+        if (!name) {
+          return of(this.emptyIcon);
+        }
+
+        return this.iconService.getSvg(name).pipe(catchError(() => of(this.emptyIcon)));
+      }),
+    ),
+    { initialValue: null, requireSync: false },
+  );
+
+  protected readonly svgContent = computed(() => this.iconContent() ?? this.emptyIcon);
+
+  protected readonly numericSize = computed(() => {
+    const current = this.size();
+    return typeof current === 'number' ? current : null;
+  });
+
+  protected readonly sizeClass = computed(() => {
+    const currentSize = this.size();
+    if (typeof currentSize === 'string') {
+      return SIZE_VARIANTS.has(currentSize) ? currentSize : 'md';
+    }
+
+    return 'md';
+  });
+
+  protected readonly roleAttr = computed(() => (this.ariaLabelAttr() ? 'img' : null));
+
+  protected readonly ariaLabelAttr = computed(() => {
+    const label = this.ariaLabel();
+    if (!label) {
+      return null;
+    }
+    const trimmed = label.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  });
+
+  protected readonly ariaHiddenAttr = computed(() =>
+    this.ariaLabelAttr() === null ? 'true' : null,
+  );
+
+  private normalizeName(name: string): string {
+    return name.trim().replace(/\.svg$/i, '');
+  }
+}

--- a/src/app/components/ui/index.ts
+++ b/src/app/components/ui/index.ts
@@ -15,6 +15,8 @@ export {
   type ToastPosition as ToastPos,
 } from './toast/toast';
 export { ToastContainerComponent } from './toast/toast-container';
+export { IconComponent } from './icon/icon';
+export { IconService } from './icon/icon.service';
 
 // Table Components
 export {

--- a/src/stories/ui/icon.stories.ts
+++ b/src/stories/ui/icon.stories.ts
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { DomSanitizer } from '@angular/platform-browser';
+import { of } from 'rxjs';
+import { IconComponent } from '../../app/components/ui/icon/icon';
+import { IconService } from '../../app/components/ui/icon/icon.service';
+import { createLightDarkComparison } from '../story-helpers';
+
+const ICON_SVGS: Record<string, string> = {
+  check: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+    <path d="M5 12.5L9.5 17 19 7.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  </svg>`,
+  logo: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+    <circle cx="32" cy="32" r="30" stroke="currentColor" stroke-width="4" />
+    <path d="M20 36c3.5-6 9-10 12-12 3 2 8.5 6 12 12" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M24 44c2.5 2 5.5 3 8 3s5.5-1 8-3" fill="currentColor" opacity="0.2" />
+  </svg>`,
+};
+
+const meta: Meta<IconComponent> = {
+  title: 'UI/Icon',
+  component: IconComponent,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: IconService,
+          useFactory: (sanitizer: DomSanitizer) => ({
+            getSvg: (name: string) => {
+              const match = name.trim() || 'check';
+              const svg = ICON_SVGS[match] ?? ICON_SVGS['check'];
+              return of(sanitizer.bypassSecurityTrustHtml(svg));
+            },
+          }),
+          deps: [DomSanitizer],
+        },
+      ],
+    }),
+  ],
+  argTypes: {
+    name: {
+      control: 'select',
+      options: Object.keys(ICON_SVGS),
+      description: 'Nombre del icono a mostrar',
+    },
+    size: {
+      control: 'text',
+      description: 'Tamaño del icono (sm, md, lg o valor numérico en px)',
+    },
+    ariaLabel: {
+      control: 'text',
+      description: 'Etiqueta accesible para describir el icono',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<IconComponent>;
+
+const renderIcon = (bindings: string) => (args: Record<string, unknown>) => ({
+  props: args,
+  template: createLightDarkComparison('app-icon', bindings),
+});
+
+export const Check: Story = {
+  args: {
+    name: 'check',
+    size: 'md',
+  },
+  render: renderIcon(`[name]="name"
+    [size]="size"
+    [ariaLabel]="ariaLabel"`),
+};
+
+export const Logo: Story = {
+  args: {
+    name: 'logo',
+    size: 'lg',
+    ariaLabel: 'Marca corporativa',
+  },
+  render: renderIcon(`[name]="name"
+    [size]="size"
+    [ariaLabel]="ariaLabel"`),
+};
+
+export const CustomPixelSize: Story = {
+  args: {
+    name: 'check',
+    size: 48,
+    ariaLabel: 'Check grande',
+  },
+  render: renderIcon(`[name]="name"
+    [size]="size"
+    [ariaLabel]="ariaLabel"`),
+};


### PR DESCRIPTION
## Summary
- add IconService to load and cache sanitized SVG assets
- introduce standalone `app-icon` component with sizing and accessibility inputs
- document usage, add Storybook story, sample assets, and Vitest coverage

## Testing
- npm run prettier
- npm run lint
- npx vitest run

Resolves #13.