### PR TITLE
Fix sidebar navigation routing issue

### DIFF
--- a/src/app/layout/sidenav/sidenav.html
+++ b/src/app/layout/sidenav/sidenav.html
@@ -110,6 +110,8 @@
               [class.rounded-full]="variant() === 'pills'"
               [class.mx-2]="variant() === 'pills'"
               [class.my-1]="variant() === 'pills'"
+              [routerLink]="item.routerLink || null"
+              routerLinkActive="active"
               (click)="onItemClick(item, $event)"
               (keydown)="onKeyDown($event, item)"
               (mouseenter)="onItemMouseEnter(item.value)"
@@ -119,7 +121,6 @@
               [attr.aria-expanded]="
                 item.children && item.children.length > 0 ? isItemExpanded(item.value) : null
               "
-              [attr.href]="item.disabled ? null : '#'"
               [attr.tabindex]="item.disabled ? -1 : 0"
               role="menuitem"
             >
@@ -219,11 +220,12 @@
                       [class.opacity-50]="child.disabled"
                       [class.cursor-not-allowed]="child.disabled"
                       [class.pointer-events-none]="child.disabled"
+                      [routerLink]="child.routerLink || null"
+                      routerLinkActive="active"
                       (click)="onItemClick(child, $event)"
                       (keydown)="onKeyDown($event, child)"
                       [attr.aria-disabled]="child.disabled"
                       [attr.aria-current]="isItemSelected(child.value) ? 'page' : null"
-                      [attr.href]="child.disabled ? null : '#'"
                       [attr.tabindex]="child.disabled ? -1 : 0"
                       role="menuitem"
                     >

--- a/src/app/layout/sidenav/sidenav.ts
+++ b/src/app/layout/sidenav/sidenav.ts
@@ -96,6 +96,12 @@ export class SidenavComponent {
       return;
     }
 
+    // Don't prevent default if item has routerLink (let Angular routing handle it)
+    // Only prevent default if no routerLink
+    if (!item.routerLink) {
+      event.preventDefault();
+    }
+
     this.selectedItem.set(item.value);
     this.itemClick.emit(item);
     this.selectionChange.emit(item);


### PR DESCRIPTION
## Summary

Fixes sidebar navigation not working when clicking on menu items. While direct URL navigation worked correctly, clicking sidebar buttons redirected to home instead of the intended route.

## Changes

- ✅ Added `routerLink` directive to sidebar navigation items (both parent and child items)
- ✅ Added `routerLinkActive="active"` for proper active state tracking  
- ✅ Updated `onItemClick` method to allow Angular router navigation
- ✅ Removed `href="#"` attributes that prevented proper routing

## Test Plan

- [x] Test direct URL navigation to `/companies` works
- [x] Test clicking sidebar "Companies" button navigates correctly
- [x] Test all sidebar navigation items route properly
- [x] Test nested menu items (Loans submenu) expand/collapse correctly
- [x] Verify router active states are highlighted properly
- [x] Test keyboard navigation still works

## Related Issue

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)